### PR TITLE
Added classes for visorless helmet selections

### DIFF
--- a/src/Addons/34thPRC_ArmourStandard/data/marines/config_weapons.hpp
+++ b/src/Addons/34thPRC_ArmourStandard/data/marines/config_weapons.hpp
@@ -1,8 +1,22 @@
 class HaloInf_Marine_GRFS_headgear; // Halo_marine_02
+class HaloInf_Marine_DES_UNSC_NV_headgear; // Halo_marine_02
 class 34thPRC_ArmourStandard_Marines_CH252_Urban : HaloInf_Marine_GRFS_headgear
 {
 	displayName="[34th] CH252 Urban";
 	author="TheBrwnKidd";
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\urban\helmet_urban_co.paa"
+	};
+}
+class 34thPRC_ArmourStandard_Marines_CH252_Urban_NV : HaloInf_Marine_DES_UNSC_NV_headgear
+{
+	displayName="[34th] CH252 Urban (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\urban\helmet_urban_co.paa"
@@ -17,10 +31,36 @@ class 34thPRC_ArmourStandard_Marines_CH252_ArcticLight : 34thPRC_ArmourStandard_
 		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_light_co.paa"
 	};
 }
+class 34thPRC_ArmourStandard_Marines_CH252_ArcticLight_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Arctic Light (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_light_co.paa"
+	};
+}
 class 34thPRC_ArmourStandard_Marines_CH252_ArcticDark : 34thPRC_ArmourStandard_Marines_CH252_Urban
 {
 	displayName="[34th] CH252 Arctic Dark";
 	author="TheBrwnKidd";
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_dark_co.paa"
+	};
+}
+class 34thPRC_ArmourStandard_Marines_CH252_ArcticDark_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Arctic Dark (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_dark_co.paa"
@@ -35,10 +75,36 @@ class 34thPRC_ArmourStandard_Marines_CH252_AridLight : 34thPRC_ArmourStandard_Ma
 		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_light_co.paa"
 	};
 }
+class 34thPRC_ArmourStandard_Marines_CH252_AridLight_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Arid Light (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_light_co.paa"
+	};
+}
 class 34thPRC_ArmourStandard_Marines_CH252_AridDark : 34thPRC_ArmourStandard_Marines_CH252_Urban
 {
 	displayName="[34th] CH252 Arid Dark";
 	author="TheBrwnKidd";
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_dark_co.paa"
+	};
+}
+class 34thPRC_ArmourStandard_Marines_CH252_AridDark_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Arid Dark (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_dark_co.paa"
@@ -53,6 +119,19 @@ class 34thPRC_ArmourStandard_Marines_CH252_WoodlandLight : 34thPRC_ArmourStandar
 		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_light_co.paa"
 	};
 }
+class 34thPRC_ArmourStandard_Marines_CH252_WoodlandLight_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Woodland Light (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_light_co.paa"
+	};
+}
 class 34thPRC_ArmourStandard_Marines_CH252_WoodlandDark : 34thPRC_ArmourStandard_Marines_CH252_Urban
 {
 	displayName="[34th] CH252 Woodland Dark";
@@ -62,10 +141,36 @@ class 34thPRC_ArmourStandard_Marines_CH252_WoodlandDark : 34thPRC_ArmourStandard
 		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_dark_co.paa"
 	};
 }
+class 34thPRC_ArmourStandard_Marines_CH252_WoodlandDark_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Woodland Dark (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_dark_co.paa"
+	};
+}
 class 34thPRC_ArmourStandard_Marines_CH252_Tropic : 34thPRC_ArmourStandard_Marines_CH252_Urban
 {
 	displayName="[34th] CH252 Woodland Tropic";
 	author="TheBrwnKidd";
+	hiddenSelectionsTextures[]=
+	{
+		"34thPRC_ArmourStandard\data\marines\tropic\helmet_tropic_co.paa"
+	};
+}
+class 34thPRC_ArmourStandard_Marines_CH252_Tropic_NV : 34thPRC_ArmourStandard_Marines_CH252_Urban_NV
+{
+	displayName="[34th] CH252 Woodland Tropic (NV)";
+	author="TheBrwnKidd & Vazya";
+	hiddenSelections[]=
+	{
+		"_Visor"
+	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\tropic\helmet_tropic_co.paa"

--- a/src/Addons/34thPRC_ArmourStandard/data/marines/config_weapons.hpp
+++ b/src/Addons/34thPRC_ArmourStandard/data/marines/config_weapons.hpp
@@ -13,10 +13,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_Urban_NV : HaloInf_Marine_DES_UNSC_NV
 {
 	displayName="[34th] CH252 Urban (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\urban\helmet_urban_co.paa"
@@ -35,10 +31,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_ArcticLight_NV : 34thPRC_ArmourStanda
 {
 	displayName="[34th] CH252 Arctic Light (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_light_co.paa"
@@ -57,10 +49,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_ArcticDark_NV : 34thPRC_ArmourStandar
 {
 	displayName="[34th] CH252 Arctic Dark (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arctic\helmet_arctic_dark_co.paa"
@@ -79,10 +67,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_AridLight_NV : 34thPRC_ArmourStandard
 {
 	displayName="[34th] CH252 Arid Light (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_light_co.paa"
@@ -101,10 +85,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_AridDark_NV : 34thPRC_ArmourStandard_
 {
 	displayName="[34th] CH252 Arid Dark (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\arid\helmet_arid_dark_co.paa"
@@ -123,10 +103,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_WoodlandLight_NV : 34thPRC_ArmourStan
 {
 	displayName="[34th] CH252 Woodland Light (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_light_co.paa"
@@ -145,10 +121,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_WoodlandDark_NV : 34thPRC_ArmourStand
 {
 	displayName="[34th] CH252 Woodland Dark (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\woodland\helmet_woodland_dark_co.paa"
@@ -167,10 +139,6 @@ class 34thPRC_ArmourStandard_Marines_CH252_Tropic_NV : 34thPRC_ArmourStandard_Ma
 {
 	displayName="[34th] CH252 Woodland Tropic (NV)";
 	author="TheBrwnKidd & Vazya";
-	hiddenSelections[]=
-	{
-		"_Visor"
-	};
 	hiddenSelectionsTextures[]=
 	{
 		"34thPRC_ArmourStandard\data\marines\tropic\helmet_tropic_co.paa"

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Visorless marine helmet options
 
 ## [0.4.0]
 ### Added


### PR DESCRIPTION
Our helmets now have a second option each with (NV) after the camo which indicates the additions. 
