### PR TITLE
model swap for the 1st MEU SAABR-96 to the OPTRE Stanchion

### DIFF
--- a/src/Addons/34thPRC_Overrides/config.cpp
+++ b/src/Addons/34thPRC_Overrides/config.cpp
@@ -20,6 +20,7 @@ class CfgPatches
 			"19thMD_Vests_Kelp", // UNSC Foundries
 			"PhoenixSystems_Exosuits", // E.P.S.M ExoMod Remastered
 			"NSWep_Weapons", //UNSC Naval Special Weapons
+			"1st_MEU_patch_weapons", //1st MEU
 		};
 	};
 };

--- a/src/Addons/34thPRC_Overrides/data/weapons/config_weapons.hpp
+++ b/src/Addons/34thPRC_Overrides/data/weapons/config_weapons.hpp
@@ -9,3 +9,4 @@
 #include "sidekick\config_weapons.hpp"
 #include "srs99rm\config_weapons.hpp"
 #include "srs99am\config_weapons.hpp"
+#include "saabr96\config_weapons.hpp"

--- a/src/Addons/34thPRC_Overrides/data/weapons/saabr96/config_weapons.hpp
+++ b/src/Addons/34thPRC_Overrides/data/weapons/saabr96/config_weapons.hpp
@@ -1,0 +1,7 @@
+class OPTRE_M99A2S3;
+class MEU_SAABR96 : OPTRE_M99A2S3
+{
+	model="OPTRE_Weapons\Sniper\M99.p3d";
+	uniformModel="OPTRE_Weapons\Sniper\M99.p3d";
+
+};

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix shoulderless marine uniforms having less carry capacity
 - Gungnir helmet camos for Marines/ODSTS
 - Naval Special Weapons SRS99AM now can use 19th Fleet SRS Ammo
+- 1st MEU SAABR-96 now uses the OPTRE Stanchion model
 
 ## 1.19.0
 ### Added


### PR DESCRIPTION
An override of the 1st MEU SAABR-96 to give it OPTRE's M99 Stanchion model

closes #299 