### PR TITLE
Feature/grapple pack

### DIFF
--- a/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
+++ b/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
@@ -2,11 +2,11 @@ class OPTRE_S12_SOLA_Jetpack; // OPTRE ---> OPTRE_Weapons
 class SC_MercerJumppack; //Scion Conflict ---> sc_newequipment2
 class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet : SC_MercerJumppack
 {
-	displayname="[34th] Series-9[B] SOLA Jump-Jet"
+	displayName="[34th] Series-9[B] SOLA Jump-Jet"
 	author="34th PRC - Vasya, Outworld Studios, & Article 2 Studios"
 	picture="\OPTRE_weapons\backpacks\icons\icon_jetpack_ca.paa";
 	scope=2;
-	scopearsenal=2;
+	scopeArsenal=2;
 	ace_gunbag=1;
 	tf_hasLRradio=1;
 	tf_range=25000;
@@ -24,4 +24,10 @@ class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet : SC_MercerJumppack
 	{
 	"optre_weapons\backpacks\data\jetpack_co.paa"
 	};
+};
+class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet_GH : 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet
+{
+	displayName="[34th] Series-9[GH] SOLA Jump-Jet";
+	author="Yandere, Outworld Studios, & Article 2 Studios"
+	sc_grapplinghook=1;
 };

--- a/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
+++ b/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
@@ -26,9 +26,3 @@ class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet : SC_MercerJumppack
 	"optre_weapons\backpacks\data\jetpack_co.paa"
 	};
 };
-class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet_GH : 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet
-{
-	displayName="[34th] Series-9[GH] SOLA Jump-Jet";
-	author="Yandere, Outworld Studios, & Article 2 Studios"
-	sc_grapplinghook=1;
-};

--- a/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
+++ b/src/Addons/34thPRC_ArmourStandard/data/odst2/backpacks/s9solajumpjet/config_vehicles.hpp
@@ -14,6 +14,7 @@ class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet : SC_MercerJumppack
 	tf_dialog="rt1523g_radio_dialog";
 	tf_subtype="digital_lr";
 	tf_dialogUpdate="call TFAR_fnc_updateLRDialogToChannel;";
+	sc_grapplinghook=1;
 	model="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 	uniformModel="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 	hiddenSelections[]=
@@ -24,10 +25,4 @@ class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet : SC_MercerJumppack
 	{
 	"optre_weapons\backpacks\data\jetpack_co.paa"
 	};
-};
-class 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet_GH : 34thPRC_ArmourStandard_ODST2_Backpacks_S9SOLAJumpJet
-{
-	displayName="[34th] Series-9[GH] SOLA Jump-Jet";
-	author="Yandere, Outworld Studios, & Article 2 Studios"
-	sc_grapplinghook=1;
 };

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Series-9 SOLA Jump-Jet (Halo variant of the Scion Conflict jumppack which includes a Gunbag and Long-Range Radio.)
+- Series-9 GH SOLA Jump-Jet (Alt version of the above with grapplinghook functionality from Scion Conflict)
 ### Updated
 - Added black hot thermals to HUL Gen 3 variants to make them leadership available
 - Yandere Recon Custom Helm

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Series-9 SOLA Jump-Jet (Halo variant of the Scion Conflict jumppack which includes a Gunbag and Long-Range Radio.)
-- Series-9 GH SOLA Jump-Jet (Alt version of the above with grapplinghook functionality from Scion Conflict)
+- SOLA Jump-Jet now has grapplehook functionality.
 ### Updated
 - Added black hot thermals to HUL Gen 3 variants to make them leadership available
 - Yandere Recon Custom Helm

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Series-9 SOLA Jump-Jet (Halo variant of the Scion Conflict jumppack which includes a Gunbag and Long-Range Radio.)
-- SOLA Jump-Jet now has grapplehook functionality.
-- Series-9 GH SOLA Jump-Jet (Alt version of the above with grapplinghook functionality from Scion Conflict)
+- Series-9 SOLA Jump-Jet (Halo variant of the Scion Conflict jumppack which includes a Gunbag, Long-Range Radio, and grapplehook functionality.)
+
 - Ace Arsenal Extended support for Immersion Cigs - Rewrite
 ### Updated
 - Added black hot thermals to HUL Gen 3 variants to make them leadership available

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SOLA Jump-Jet now has grapplehook functionality.
 - Series-9 GH SOLA Jump-Jet (Alt version of the above with grapplinghook functionality from Scion Conflict)
 - Ace Arsenal Extended support for Immersion Cigs - Rewrite
-
 ### Updated
 - Added black hot thermals to HUL Gen 3 variants to make them leadership available
 - Yandere Recon Custom Helm


### PR DESCRIPTION
Removes second Jump-Pack because it is no longer needed. Having both the grapple hook and a grapple hook enabled jump pack does not cause bugs with the hook functionality and allows for those who want other face to utilize it and those who want the wrist launcher model to have it.