### PR TITLE
Feature/34th kjw jumpjet balance tweaks

### DIFF
--- a/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
+++ b/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
@@ -17,9 +17,9 @@ class CfgPatches
 class CfgVehicles
 {
 class Bag_Base;
-class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet : Bag_Base
+class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJetpack : Bag_Base
 {
-	displayName="[34th] Series-9[B] SOLA Jump-Jet";
+	displayName="[34th] Series-9[B] SOLA Jetpack";
 	author="34th PRC - Vasya, Jennderqueer, KJW, & Article 2 Studios";
 	picture="\OPTRE_weapons\backpacks\icons\icon_jetpack_ca.paa";
 	scope=2;
@@ -34,14 +34,14 @@ class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet : Bag_Base
 	sc_grapplinghook=1;
 	jen_jetpacks_core_isJetpack=1;
 	jen_jetpacks_core_acceleration=1.75;
-	jen_jetpacks_core_drag=9;
+	jen_jetpacks_core_drag=10;
 	jen_jetpacks_core_fuelCoef=1;
 	jen_jetpacks_core_fuelCapacity=150;
 	jen_jetpacks_core_heatCoef=8;
 	jen_jetpacks_core_coolCoef=8;
-	jen_jetpacks_core_ascensionCoef=1.2;
+	jen_jetpacks_core_ascensionCoef=1.25;
 	jen_jetpacks_core_jumpCoef=1;
-	jen_jetpacks_core_strafeCoef=0.85;
+	jen_jetpacks_core_strafeCoef=0.7;
 	model="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 	uniformModel="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 	hiddenSelections[]=

--- a/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
+++ b/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
@@ -16,41 +16,43 @@ class CfgPatches
 };
 class CfgVehicles
 {
-	class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet
+class Bag_Base;
+class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet : Bag_Base
+{
+	displayName="[34th] Series-9[B] SOLA Jump-Jet";
+	author="34th PRC - Vasya, Jennderqueer, KJW, & Article 2 Studios";
+	picture="\OPTRE_weapons\backpacks\icons\icon_jetpack_ca.paa";
+	scope=2;
+	scopeArsenal=2;
+	ace_gunbag=1;
+	tf_hasLRradio=1;
+	tf_range=25000;
+	tf_encryptionCode="tf_west_radio_code";
+	tf_dialog="rt1523g_radio_dialog";
+	tf_subtype="digital_lr";
+	tf_dialogUpdate="call TFAR_fnc_updateLRDialogToChannel;";
+	sc_grapplinghook=1;
+	jen_jetpacks_core_isJetpack=1;
+	jen_jetpacks_core_acceleration=1.75;
+	jen_jetpacks_core_drag=9;
+	jen_jetpacks_core_fuelCoef=1;
+	jen_jetpacks_core_fuelCapacity=150;
+	jen_jetpacks_core_heatCoef=8;
+	jen_jetpacks_core_coolCoef=8;
+	jen_jetpacks_core_ascensionCoef=1.2;
+	jen_jetpacks_core_jumpCoef=1;
+	jen_jetpacks_core_strafeCoef=0.85;
+	model="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
+	uniformModel="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
+	hiddenSelections[]=
 	{
-		displayName="[34th] Series-9[B] SOLA Jump-Jet";
-		author="34th PRC - Vasya, Jennderqueer, KJW, & Article 2 Studios";
-		picture="\OPTRE_weapons\backpacks\icons\icon_jetpack_ca.paa";
-		scope=2;
-		scopeArsenal=2;
-		ace_gunbag=1;
-		tf_hasLRradio=1;
-		tf_range=25000;
-		tf_encryptionCode="tf_west_radio_code";
-		tf_dialog="rt1523g_radio_dialog";
-		tf_subtype="digital_lr";
-		tf_dialogUpdate="call TFAR_fnc_updateLRDialogToChannel;";
-		sc_grapplinghook=1;
-		jen_jetpacks_core_acceleration=6;
-		jen_jetpacks_core_drag=9;
-		jen_jetpacks_core_fuelCoef=1;
-		jen_jetpacks_core_fuelCapacity=150;
-		jen_jetpacks_core_heatCoef=8;
-		jen_jetpacks_core_coolCoef=8;
-		jen_jetpacks_core_ascensionCoef=1.25;
-		jen_jetpacks_core_jumpCoef=1;
-		jen_jetpacks_core_strafeCoef=0.25;
-		model="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
-		uniformModel="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
-		hiddenSelections[]=
-		{
-			"camo"
-		};
-		hiddenSelectionsTextures[]=
-		{
-			"optre_weapons\backpacks\data\jetpack_co.paa"
-		};
-		maximumLoad=600;
-		mass=20;
+		"camo"
 	};
+	hiddenSelectionsTextures[]=
+	{
+		"optre_weapons\backpacks\data\jetpack_co.paa"
+	};
+	maximumLoad=600;
+	mass=20;
+};
 };

--- a/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
+++ b/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/kjwjetpacks/config.cpp
@@ -16,8 +16,7 @@ class CfgPatches
 };
 class CfgVehicles
 {
-	class jen_jetpacks_example_mk5Jetpack_nato; //KJW's Jetpacks ---> jen_jetpacks_example
-	class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet : jen_jetpacks_example_mk5Jetpack_nato
+	class 34thPRC_ArmourStandard_jumppacks_kjwjetpacks_S9BSOLAJumpJet
 	{
 		displayName="[34th] Series-9[B] SOLA Jump-Jet";
 		author="34th PRC - Vasya, Jennderqueer, KJW, & Article 2 Studios";
@@ -32,6 +31,15 @@ class CfgVehicles
 		tf_subtype="digital_lr";
 		tf_dialogUpdate="call TFAR_fnc_updateLRDialogToChannel;";
 		sc_grapplinghook=1;
+		jen_jetpacks_core_acceleration=6;
+		jen_jetpacks_core_drag=9;
+		jen_jetpacks_core_fuelCoef=1;
+		jen_jetpacks_core_fuelCapacity=150;
+		jen_jetpacks_core_heatCoef=8;
+		jen_jetpacks_core_coolCoef=8;
+		jen_jetpacks_core_ascensionCoef=1.25;
+		jen_jetpacks_core_jumpCoef=1;
+		jen_jetpacks_core_strafeCoef=0.25;
 		model="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 		uniformModel="OPTRE_Weapons\Backpacks\jetpack_on.p3d";
 		hiddenSelections[]=

--- a/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/scionconflict/config.cpp
+++ b/src/Addons/34thPRC_ArmourStandard/patches/jumppacks/scionconflict/config.cpp
@@ -17,9 +17,9 @@ class CfgPatches
 class CfgVehicles
 {
 	class SC_MercerJumppack; //Scion Conflict ---> sc_newequipment2
-	class 34thPRC_ArmourStandard_jumppacks_scionconflict_S9SSOLAJumpJet : SC_MercerJumppack
+	class 34thPRC_ArmourStandard_jumppacks_scionconflict_S9SSOLAThrusterPack : SC_MercerJumppack
 	{
-		displayName="[34th] Series-9[S] SOLA Jump-Jet";
+		displayName="[34th] Series-9[X] SOLA Thruster Pack";
 		author="34th PRC - Vasya, Outworld Studios, & Article 2 Studios";
 		picture="\OPTRE_weapons\backpacks\icons\icon_jetpack_ca.paa";
 		scope=2;

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Updated
+- Series 9[B] SOLA Jetpack(KJW's Jetpacks) balance pass. Functions very closely to the Halo: Reach Jetpack now.
+- Series 9[X] SOLA Thruster Pack(Scion Conflict) will remain an option as 'experimental' escape & evasion equipment.
 
 ## 0.24.2
 ### Fix


### PR DESCRIPTION
Balance pass has been green-lit, and the Scion Conflict variant has been renamed to reflect it's place as an experimental evasion device.