### PR TITLE
Fix/airburst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 hemtt
 hemtt.exe
 *.biprivatekey
+include
 
 .vscode
 build-config.json

--- a/src/Addons/34thPRC_Functions/$PREFIX$
+++ b/src/Addons/34thPRC_Functions/$PREFIX$
@@ -1,0 +1,1 @@
+34thPRC_Functions

--- a/src/Addons/34thPRC_Functions/M99A2S3A/a2s3a_preinit.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/a2s3a_preinit.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[a2s3a_preinit.sqf] "
 
 diag_log format[MACRO_DIAG_LOG,format [MACRO_SCRIPT+"Loading"]];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/config.cpp
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/config.cpp
@@ -152,25 +152,25 @@ class RscButton
 	colorBorder[]={0,0,0,1};
 	soundEnter[]=
 	{
-		"\A3\ui_f\data\sound\RscButton\soundEnter",
+		"\A3\ui_f\data\sound\RscButton\soundEnter.wss",
 		0.090000004,
 		1
 	};
 	soundPush[]=
 	{
-		"\A3\ui_f\data\sound\RscButton\soundPush",
+		"\A3\ui_f\data\sound\RscButton\soundPush.wss",
 		0.090000004,
 		1
 	};
 	soundClick[]=
 	{
-		"\A3\ui_f\data\sound\RscButton\soundClick",
+		"\A3\ui_f\data\sound\RscButton\soundClick.wss",
 		0.090000004,
 		1
 	};
 	soundEscape[]=
 	{
-		"\A3\ui_f\data\sound\RscButton\soundEscape",
+		"\A3\ui_f\data\sound\RscButton\soundEscape.wss",
 		0.090000004,
 		1
 	};

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/ace/airburst_ammunition_handler.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/ace/airburst_ammunition_handler.sqf
@@ -16,6 +16,7 @@
  */
 
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst ace airburst pfh.sqf] "   //Addition
 
 (_this select 0) params ["_vehicle", "_projectile", "_zeroing",["_subMunitionClass","ACE_B_35mm_ABM_Helper"]];  //Addition

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/conditions.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/conditions.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst condition.sqf] "
 
 //Could be a player or vehicle

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/fired_eh.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/fired_eh.sqf
@@ -17,6 +17,7 @@
  */
 
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst fired_eh.sqf] "
 
 params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_gunner"];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/handle_is_burst.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/handle_is_burst.sqf
@@ -11,6 +11,7 @@
  */
 
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst fired_server.sqf] "
 
 params ["_magazine","_projectile","_unit"];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/keybind.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/keybind.sqf
@@ -1,5 +1,6 @@
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst keybinds.sqf] "
 
 diag_log format [MACRO_SCRIPT+"Registering keybinds"];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/lase_distance_infantry.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/lase_distance_infantry.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst lase_distance_infantry.sqf] "
 
 params[["_unit",ace_player]];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/lase_distance_vehicle.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/lase_distance_vehicle.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst lase_distance_vehicle.sqf] "
 
 params[["_unit",ace_player]];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/set_fuse_distance.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/set_fuse_distance.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst setFuseDistance.sqf] "
 
 params [["_unit",ace_player],["_distance",0]];

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onConfirm.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onConfirm.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst onConfirm.sqf] "
 
 //Save the value

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onExit.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onExit.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst onExit.sqf] "
 
 closeDialog 10846;

--- a/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onLoad.sqf
+++ b/src/Addons/34thPRC_Functions/M99A2S3A/functions/ui/onLoad.sqf
@@ -1,4 +1,5 @@
 #include "\34thPRC_Functions\M99A2S3A\_includes\defines_macros.hpp"
+#undef MACRO_SCRIPT
 #define MACRO_SCRIPT "[airburst onload.sqf] "
 
 params["_display"];

--- a/src/Addons/34thPRC_WeaponsStandard/M99A2S3A/config.cpp
+++ b/src/Addons/34thPRC_WeaponsStandard/M99A2S3A/config.cpp
@@ -26,7 +26,7 @@ class CfgWeapons
 	class 34thPRC_M99A2S3A : OPTRE_M99A2S3
 	{
 		baseWeapon="34thPRC_M99A2S3A";
-		displayName="[34th] M99A2S3A 'Stanchion Airbusrt'";
+		displayName="[34th] M99A2S3A 'Stanchion Airburst'";
 		magazines[]=
 		{
 			"34th_M99A2S3A_mag",
@@ -101,28 +101,28 @@ class CfgAmmo
 		explosionSoundEffect="DefaultExplosion";
 		soundHit1[]=
 		{
-			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_01",
+			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_01.wss",
 			3.1622801,
 			1,
 			1500
 		};
 		soundHit2[]=
 		{
-			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_02",
+			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_02.wss",
 			3.1622801,
 			1,
 			1500
 		};
 		soundHit3[]=
 		{
-			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_03",
+			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_03.wss",
 			3.1622801,
 			1,
 			1500
 		};
 		soundHit4[]=
 		{
-			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_04",
+			"A3\Sounds_F\arsenal\explosives\Grenades\Explosion_gng_grenades_04.wss",
 			3.1622801,
 			1,
 			1500

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Series 9[B] SOLA Jetpack(KJW's Jetpacks) balance pass. Functions very closely to the Halo: Reach Jetpack now.
 - Series 9[X] SOLA Thruster Pack(Scion Conflict) will remain an option as 'experimental' escape & evasion equipment.
 
+### Fix
+- Airburst Rifle: short description spelling, script now uses #undef to prevent potential for unexpected override, sound files now have file endings in their path
+
 ## 0.24.2
 ### Fix
 - Scripting nonsense


### PR DESCRIPTION
The Airburst rifle has had its short description named fixed, #undef has been added to multiple script files to prevent any unexpected overriding, file types have been added to the paths of sounds files called within the scripts and config.

Closes #398 