### PR TITLE
Fix/falcon mfd error

### DIFF
--- a/addons/overrides/data/OPTRE Patches/optre_M638/config.cpp
+++ b/addons/overrides/data/OPTRE Patches/optre_M638/config.cpp
@@ -1,0 +1,27 @@
+class CfgPatches
+{
+	class 34thPRC_OPTRE_M638
+	{
+		author="34th PRC Modding Team, Over Yandere";
+		addonRootClass="34thPRC_Overrides";
+		requiredAddons[]=
+		{
+			"34thPRC_Overrides", "34thPRC_Magazines",
+			"A3_Weapons_F", //Arma Weapons_F
+			"OPTRE_Weapons_Vehicle", //[Dev] Optre -> OPTRE_Weapons -> Vehicle
+		};
+		units[]={};
+	};
+};
+
+class CfgWeapons
+{
+	class gatling_20mm;
+	class OPTRE_M638: gatling_20mm
+	{
+		magazines[]+=
+		{
+			"34thPRC_Magazines_2000Rnd_20mmHE",
+		};
+	};
+};

--- a/addons/overrides/data/OPTRE Patches/optre_falcon/config.cpp
+++ b/addons/overrides/data/OPTRE Patches/optre_falcon/config.cpp
@@ -103,7 +103,7 @@ class CfgVehicles
 	{
 		weapons[]=
 		{
-			"34thPRC_M638",
+			"OPTRE_M638",
 			"CMFlareLauncher",
 			"Laserdesignator_pilotCamera"
 		};
@@ -252,6 +252,17 @@ class CfgVehicles
 					};
 				};
 			};
+		};
+	};
+	class OPTRE_UNSC_falcon_S;
+	class OPTRE_UNSC_falcon_armed_S: OPTRE_UNSC_falcon_S
+	{
+		magazines[]=
+		{
+			"34thPRC_Magazines_2000Rnd_20mmHE",
+			"34thPRC_Magazines_2000Rnd_20mmHE",
+			"168Rnd_CMFlare_Chaff_Magazine",
+			"Laserbatteries"
 		};
 	};
 };

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fix
+- Revert OPTRE Falcon to using OPTRE gun, override OPTRE gun to accept new magazine.
 
 ## 0.27.0
 ### Added


### PR DESCRIPTION
Reverts falcon base gun to using OPTRE's M638 autocannon but then overrides the autocannon to accept our ammo / magazine and then overrides the 144S DAP falcon to use that new ammo by default.

This should hopefully fix the MFD error.