### PR TITLE
0.29.0

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,6 +1,6 @@
 //Update to match changelog version on release
 #define MAJOR 0
-#define MINOR 28
+#define MINOR 29
 #define PATCH 0
 
 #define VERSION     MAJOR.MINOR

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - overrides pbo updated prefix
 - main pbo prefix updated
 - sc_uniforms prefix updated
-
 ### Removed
 - unnessecary prefix files in overrides
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 0.29.0
 ### Updated
 - Filepaths for scripts updated to Hemtt requirements
 - armour_standard pbo updated all internal file paths and prefix


### PR DESCRIPTION
Release Prep for 0.29.0

## 0.29.0
### Updated
- Filepaths for scripts updated to Hemtt requirements
- armour_standard pbo updated all internal file paths and prefix
- armour_custom pbo updated all internal file paths and prefix
- ace_arsenal_extended pbo updated all internal file paths and prefix
- faction_brimstone pbo updated all internal file paths and prefix
- loading_screens pbo updated all internal file paths and prefix
- markers pbo updated all internal file paths and prefix
- music_radio pbo updated prefix
- vehicles pbo updated prefix
- weapons_standard pbo updated prefix
- sec_guestpack pbo updated all internal file paths and prefix
- overrides pbo updated prefix
- main pbo prefix updated
- sc_uniforms prefix updated

### Removed
- unnessecary prefix files in overrides

Switches the mod to a Hemtt build
