### PR TITLE
Hotfix: 0.31.1 - rvmats and M52-R

### DIFF
--- a/addons/ace_arsenal_extended/data/aax_models/vehicles/armour_standard/odst2_rucksack/config.hpp
+++ b/addons/ace_arsenal_extended/data/aax_models/vehicles/armour_standard/odst2_rucksack/config.hpp
@@ -40,7 +40,7 @@ class 34thPRC_ArmourStandard_ODST_M52_Rucksack_Urban //New Rucksacks
 		label="Model";
 		alwaysSelectable=1;
 		changeingame=0;
-		values[]= {"standard","medic","gunbag","rto"};
+		values[]= {"standard","medic","gunbag","radio"};
 		class standard
 		{
 			label="Standard";
@@ -53,7 +53,7 @@ class 34thPRC_ArmourStandard_ODST_M52_Rucksack_Urban //New Rucksacks
 		{
 			label="Gunbag";
 		};
-		class rto
+		class radio
 		{
 			label="RTO/JTAC";
 		};

--- a/addons/armour_standard/data/odst2/34th_odst_helmet.rvmat
+++ b/addons/armour_standard/data/odst2/34th_odst_helmet.rvmat
@@ -7,7 +7,7 @@ specularPower = 25;
 PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\odst_helmet_NOHQ.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\odst_helmet_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -37,7 +37,7 @@ class Stage3 {
 	};
 };
 class Stage4 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\odst_helmet_AS.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\odst_helmet_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -47,7 +47,7 @@ class Stage4 {
 	};
 };
 class Stage5 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\odst_helmet_SMDI.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\odst_helmet_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/armour_standard/data/odst2/34th_odst_visor.rvmat
+++ b/addons/armour_standard/data/odst2/34th_odst_visor.rvmat
@@ -12,7 +12,7 @@ PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1
 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_NOHQ.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform
 	{
@@ -48,7 +48,7 @@ class Stage3
 };
 class Stage4
 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_AS.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_AS.paa";
 	uvSource = "tex";
 	class uvTransform
 	{
@@ -60,7 +60,7 @@ class Stage4
 };
 class Stage5
 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_SMDI.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\visor\34th_odst_visor_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform
 	{

--- a/addons/armour_standard/data/odst2/M52_Rucksack.rvmat
+++ b/addons/armour_standard/data/odst2/M52_Rucksack.rvmat
@@ -7,7 +7,7 @@ specularPower = 25;
 PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_NOHQ.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -37,7 +37,7 @@ class Stage3 {
 	};
 };
 class Stage4 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_AS.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -47,7 +47,7 @@ class Stage4 {
 	};
 };
 class Stage5 {
-	texture = "\z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_SMDI.paa";
+	texture = "z\34thprc\addons\armour_standard\data\odst2\34th_odst_rucksack_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/armour_standard/data/odst2/cqb_shoulders.rvmat
+++ b/addons/armour_standard/data/odst2/cqb_shoulders.rvmat
@@ -8,7 +8,7 @@ PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_cqb_NOHQ.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_cqb_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -40,7 +40,7 @@ class Stage3 {
 };
 class Stage4
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_cqb_AS.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_cqb_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -51,7 +51,7 @@ class Stage4
 };
 class Stage5
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_cqb_SMDI.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_cqb_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/armour_standard/data/odst2/marksman_shoulders.rvmat
+++ b/addons/armour_standard/data/odst2/marksman_shoulders.rvmat
@@ -8,7 +8,7 @@ PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_marksman_NOHQ.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_marksman_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -40,7 +40,7 @@ class Stage3 {
 };
 class Stage4
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_marksman_AS.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_marksman_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -51,7 +51,7 @@ class Stage4
 };
 class Stage5
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_marksman_SMDI.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_marksman_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/armour_standard/data/odst2/odst_shoulders.rvmat
+++ b/addons/armour_standard/data/odst2/odst_shoulders.rvmat
@@ -8,7 +8,7 @@ PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_NOHQ.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -40,7 +40,7 @@ class Stage3 {
 };
 class Stage4
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_AS.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -51,7 +51,7 @@ class Stage4
 };
 class Stage5
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_SMDI.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_shoulders_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/armour_standard/data/odst2/odst_vest.rvmat
+++ b/addons/armour_standard/data/odst2/odst_vest.rvmat
@@ -8,7 +8,7 @@ PixelShaderID = "Super";
 VertexShaderID = "Super";
 class Stage1
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_vest_NOHQ.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_vest_NOHQ.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -40,7 +40,7 @@ class Stage3 {
 };
 class Stage4
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_vest_AS.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_vest_AS.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };
@@ -51,7 +51,7 @@ class Stage4
 };
 class Stage5
 {
-	texture="\z\34thprc\addons\armour_standard\data\odst2\odst_vest_SMDI.paa";
+	texture="z\34thprc\addons\armour_standard\data\odst2\odst_vest_SMDI.paa";
 	uvSource = "tex";
 	class uvTransform {
 		aside[] = { 1, 0, 0 };

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,7 +1,7 @@
 //Update to match changelog version on release
 #define MAJOR 0
 #define MINOR 31
-#define PATCH 0
+#define PATCH 1
 
 
 #define VERSION     MAJOR.MINOR

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Fixed
+- ODST rvmats had erroneous leading \s slip back into their paths, these have been removed.
+- ODST M52-R aax selection fix
 
 ## 0.31.0
 ### Updated

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-## Fixed
+## 0.31.1
+### Fixed
 - ODST rvmats had erroneous leading \s slip back into their paths, these have been removed.
 - ODST M52-R aax selection fix
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ## 0.31.1
 ### Fixed
 - ODST rvmats had erroneous leading \s slip back into their paths, these have been removed.


### PR DESCRIPTION
Removes unneeded \s before rvmat paths, and reverted the "rto" class back to "radio" on the aax class for the M52 to restore selectability.